### PR TITLE
Remove the Logistics department

### DIFF
--- a/Club Constitution.md
+++ b/Club Constitution.md
@@ -32,7 +32,6 @@ We, the students, for the promotion of good government, good sportsmanship, stud
 - Vice President
 - Business & Marketing Officer
 - Controls Officer
-- Logistics Officer
 - Mechanical Officer
 - Safety Officer
 - Strategy Officer
@@ -43,7 +42,6 @@ We, the students, for the promotion of good government, good sportsmanship, stud
 ## The team has 6 departments
 - Business & Marketing Department
 - Controls Department
-- Logistics Department
 - Mechanical Department
 - Safety Department
 - Strategy Department


### PR DESCRIPTION
The administrative responsibilities (parent emails, member list, onboarding, forms) will be moved to the Pres. and VP. 
All money-related responsibilities (purchase orders, inventorying) will be moved to to the business department.

### Reasons FOR:
- Logistics department has been extremely small with very little consistent responsibilities
- Disconnected from the admin of the team
- Difficult to find members for the position & department due to its nature
- Business does want more responsibilities and is willing to take on the money side
- With a VP position now, a lot more responsibilities can be handled by the Pres/VP of the team

### Reasons AGAINST:
- It's industry standard to have a logistics department
- We can pivot to assigning more responsibilities to the logistics department to keep them busy
- We can market more towards the position for members to take it on
